### PR TITLE
fix: auto-import `getQueryKey`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -40,6 +40,7 @@ export default defineNuxtModule<ModuleOptions>({
       { name: 'useClient', from: join(runtimeDir, 'client') },
       { name: 'useAsyncQuery', from: join(runtimeDir, 'client') },
       { name: 'useClientHeaders', from: join(runtimeDir, 'client') },
+      { name: 'getQueryKey', from: join(runtimeDir, 'client') },
     ])
 
     addServerHandler({


### PR DESCRIPTION
Method `getQueryKey` doesn't available with auto-imports