### PR TITLE
feat: use globalThis.$fetch to call API handler directly on server-side

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -5,7 +5,7 @@ import Module from '../src/module'
 export default defineNuxtConfig({
   modules: [Module],
   runtimeConfig: {
-    baseURL: 'http://localhost:3000',
+    baseURL: '',
   },
   typescript: {
     strict: true,

--- a/src/module.ts
+++ b/src/module.ts
@@ -16,7 +16,7 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: 'trpc',
   },
   defaults: {
-    baseURL: 'http://localhost:3000',
+    baseURL: '',
     endpoint: '/trpc',
   },
   async setup(options, nuxt) {

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -20,11 +20,11 @@ export default defineNuxtPlugin((nuxtApp) => {
         ...headers,
       }
     },
-    fetch: (input, options) => 
+    fetch: (input, options) =>
       globalThis.$fetch.raw(input.toString(), options).then(response => ({
         ...response,
         json: () => Promise.resolve(response._data),
-      }))
+      })),
   })
 
   nuxtApp.provide('client', client)

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -10,14 +10,21 @@ export default defineNuxtPlugin((nuxtApp) => {
   const config = useRuntimeConfig().public.trpc
   const headers = useRequestHeaders()
   const otherHeaders = useClientHeaders()
+
+  const baseURL = process.server ? '' : config.baseURL
   const client = trpc.createTRPCClient<AppRouter>({
-    url: `${config.baseURL}${config.endpoint}`,
+    url: `${baseURL}${config.endpoint}`,
     headers: () => {
       return {
         ...unref(otherHeaders),
         ...headers,
       }
     },
+    fetch: (input, options) => 
+      globalThis.$fetch.raw(input.toString(), options).then(response => ({
+        ...response,
+        json: () => Promise.resolve(response._data),
+      }))
   })
 
   nuxtApp.provide('client', client)


### PR DESCRIPTION
Resolve #4 and #14.

Theoretically, just by setting `fetch` as `globalThis.$fetch.raw` when invoking `createTRPCClient` method will do the trick.
```ts
const client = trpc.createTRPCClient<AppRouter>({
  ...,
  fetch: globalThis.$fetch.raw,
})
```

However, `ohmyfetch` always try to parse response body before returning `FetchResponse`, which leads to error when trpc client calls `response.json()` since response body has already been used. So we provide a _fake_ `json` method returning the parsed JSON.
```ts
fetch: (input, options) => 
  globalThis.$fetch.raw(input.toString(), options).then(response => ({
    ...response,
    json: () => Promise.resolve(response._data),
  }))
```

`ohmyfetch` behaves differently with `Fetch` API when server returns an error (like HTTP 401 and 500). `Fetch` API returns the response normally while `ohmyfetch` throws a custom error. Here we catch the `FetchError` thrown by `ohmyfetch` so that TRPC client can handle such errors as expected, like parsing the TRPC error shape.
```ts
fetch: (input, options) => 
  globalThis.$fetch.raw(input.toString(), options)
    .catch((e) => {
      if (e instanceof FetchError && e.response)
        return e.response

        throw e
      })
```

Nuxt uses the first letter (`/`) of request url to determine whether to perform a real fetch or just to call API handler directly. So it's necessary to set `baseURL` as empty string to make sure the request url starts with a '/' when fetching on server-side.