### PR TITLE
fix: don't discard error in client

### DIFF
--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -51,16 +51,13 @@ export async function useAsyncQuery<
 ): Promise<AsyncData<PickFrom<ReturnType<Transform>, PickKeys>, TError>> {
   const { $client } = useNuxtApp()
   const key = getQueryKey(pathAndInput)
-  const serverError = useState<TError | null>(`error-${key}`, () => null)
   const { error, data, ...rest } = await useAsyncData(
     key,
     () => $client.query(...pathAndInput),
     // @ts-expect-error: Internal
     options,
-  )
-
-  if (process.server && error.value && !serverError.value)
-    serverError.value = error.value as any
+    )
+  const serverError = useState<TError | null>(`error-${key}`, () => error.value)
 
   if (data.value)
     serverError.value = null

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -51,13 +51,16 @@ export async function useAsyncQuery<
 ): Promise<AsyncData<PickFrom<ReturnType<Transform>, PickKeys>, TError>> {
   const { $client } = useNuxtApp()
   const key = getQueryKey(pathAndInput)
+  const serverError = useState<TError | null>(`error-${key}`, () => null)
   const { error, data, ...rest } = await useAsyncData(
     key,
     () => $client.query(...pathAndInput),
     // @ts-expect-error: Internal
     options,
     )
-  const serverError = useState<TError | null>(`error-${key}`, () => error.value)
+
+  if (error.value && !serverError.value)
+    serverError.value = error.value as any
 
   if (data.value)
     serverError.value = null


### PR DESCRIPTION
This resolves #9  
The main issue is that the client tries to use `serverError` from `useState` and ignores the `error` from `useAsyncData`.  
I'm not exactly sure how `serverError` is populated. I assume it has something to do with SSR. However in case without SSR the returned error is always `null`.

The proposed solution is to use the error from `useAsyncData` as initial value for `useState`.  
```ts
const serverError = useState<TError | null>(`error-${key}`, () => error.value)
```