### PR TITLE
feat: data transformer support

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "nuxt": "3.0.0-rc.11",
     "pnpm": "^7.5.0",
     "trpc-nuxt": "workspace:*",
-    "zod": "^3.16.0"
+    "zod": "^3.16.0",
+    "superjson": "^1.10.1"
   },
   "eslintConfig": {
     "extends": "@antfu",

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,4 +1,5 @@
-import { defineNuxtConfig } from 'nuxt'
+import { defineNuxtConfig } from 'nuxt/config'
+import superjson from 'superjson'
 import Module from '../src/module'
 
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
@@ -6,6 +7,11 @@ export default defineNuxtConfig({
   modules: [Module],
   runtimeConfig: {
     baseURL: '',
+    public: {
+      trpc: {
+        transformer: superjson,
+      },
+    },
   },
   typescript: {
     strict: true,

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -24,6 +24,8 @@ const addTodo = async () => {
     console.log(e)
   }
 }
+
+console.log('Current date', await client.query('getCurrentDate'))
 </script>
 
 <template>

--- a/playground/pages/todo/[id].vue
+++ b/playground/pages/todo/[id].vue
@@ -11,8 +11,8 @@ const { data: todo, pending, error } = await useAsyncQuery(['getTodo', Number(ro
     {{ error.data.code }}
   </div>
   <div v-else>
-    ID: {{ todo.id }} <br>
-    Title: {{ todo.title }} <br>
-    Completed: {{ todo.completed }}
+    ID: {{ todo?.id }} <br>
+    Title: {{ todo?.title }} <br>
+    Completed: {{ todo?.completed }}
   </div>
 </template>

--- a/playground/server/trpc/index.ts
+++ b/playground/server/trpc/index.ts
@@ -1,7 +1,9 @@
-import * as trpc from '@trpc/server'
 import type { inferAsyncReturnType } from '@trpc/server'
-import { z } from 'zod'
 import type { CompatibilityEvent } from 'h3'
+
+import * as trpc from '@trpc/server'
+import superjson from 'superjson'
+import { z } from 'zod'
 
 const baseURL = 'https://jsonplaceholder.typicode.com'
 
@@ -14,6 +16,8 @@ const TodoShape = z.object({
 
 export type Todo = z.infer<typeof TodoShape>
 
+export const transformer = superjson
+
 export const router = trpc.router<Context>()
   .query('getTodos', {
     async resolve() {
@@ -24,6 +28,11 @@ export const router = trpc.router<Context>()
     input: z.number(),
     async resolve(req) {
       return await $fetch<Todo>(`${baseURL}/todos/${req.input}`)
+    },
+  })
+  .query('getCurrentDate', {
+    async resolve() {
+      return new Date()
     },
   })
   .mutation('addTodo', {
@@ -50,4 +59,4 @@ export async function createContext(event: CompatibilityEvent) {
   }
 }
 
-  type Context = inferAsyncReturnType<typeof createContext>
+type Context = inferAsyncReturnType<typeof createContext>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ importers:
       ohash: ^0.1.5
       pathe: ^0.3.0
       pnpm: ^7.5.0
+      superjson: ^1.10.1
       trpc-nuxt: workspace:*
       ufo: ^0.8.5
       zod: ^3.16.0
@@ -42,6 +43,7 @@ importers:
       eslint: 8.19.0
       nuxt: 3.0.0-rc.11_eslint@8.19.0
       pnpm: 7.5.1
+      superjson: 1.10.1
       trpc-nuxt: 'link:'
       zod: 3.17.3
 
@@ -1925,6 +1927,13 @@ packages:
 
   /cookie-es/0.5.0:
     resolution: {integrity: sha512-RyZrFi6PNpBFbIaQjXDlFIhFVqV42QeKSZX1yQIl6ihImq6vcHNGMtqQ/QzY3RMPuYSkvsRwtnt5M9NeYxKt0g==}
+
+  /copy-anything/3.0.2:
+    resolution: {integrity: sha512-CzATjGXzUQ0EvuvgOCI6A4BGOo2bcVx8B+eC2nF862iv9fopnPQwlrbACakNCHRIJbCSBj+J/9JeDf60k64MkA==}
+    engines: {node: '>=12.13'}
+    dependencies:
+      is-what: 4.1.7
+    dev: true
 
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -3941,6 +3950,11 @@ packages:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
       call-bind: 1.0.2
+    dev: true
+
+  /is-what/4.1.7:
+    resolution: {integrity: sha512-DBVOQNiPKnGMxRMLIYSwERAS5MVY1B7xYiGnpgctsOFvVDz9f9PFXXxMcTOHuoqYp4NK9qFYQaIC1NRRxLMpBQ==}
+    engines: {node: '>=12.13'}
     dev: true
 
   /is-wsl/2.2.0:
@@ -5986,6 +6000,13 @@ packages:
       browserslist: 4.21.4
       postcss: 8.4.16
       postcss-selector-parser: 6.0.10
+    dev: true
+
+  /superjson/1.10.1:
+    resolution: {integrity: sha512-7fvPVDHmkTKg6641B9c6vr6Zz5CwPtF9j0XFExeLxJxrMaeLU2sqebY3/yrI3l0K5zJ+H9QA3H+lIYj5ooCOkg==}
+    engines: {node: '>=10'}
+    dependencies:
+      copy-anything: 3.0.2
     dev: true
 
   /supports-color/5.5.0:

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,11 +3,13 @@ import { join, resolve } from 'pathe'
 import { defu } from 'defu'
 import dedent from 'dedent'
 
+import type { DataTransformerOptions } from '@trpc/server'
 import { addImports, addPlugin, addServerHandler, addTemplate, defineNuxtModule } from '@nuxt/kit'
 
 export interface ModuleOptions {
   baseURL: string
   endpoint: string
+  transformer: DataTransformerOptions | undefined
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -18,6 +20,7 @@ export default defineNuxtModule<ModuleOptions>({
   defaults: {
     baseURL: '',
     endpoint: '/trpc',
+    transformer: undefined,
   },
   async setup(options, nuxt) {
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))


### PR DESCRIPTION
This PR adds the option to define native TRPC data transformers for the server and the client. Defining server data transformers was as easy as adding another named export to the server configuration.

However, the client side data transformer support was a lot more involved. As I couldn't figure out how to dynamically import, the previously mentioned named export.  (I think it's not even possible to dynamically import files in nuxt plugins). So I ended up moving the client config into the runtime config.

PS: maybe the server config should also be defined via the runtime config instead of using the magic import export combo 

This resolves #19