### PR TITLE
Update 1.installation.md

### DIFF
--- a/docs/content/1.get-started/1.installation.md
+++ b/docs/content/1.get-started/1.installation.md
@@ -8,15 +8,15 @@ description: tRPC-Nuxt provides first class integration with tRPC.
 ::code-group
 
 ```bash [pnpm]
-pnpm add @trpc/server@next @trpc/client@next trpc-nuxt zod
+pnpm add @trpc/server @trpc/client trpc-nuxt zod
 ```
 
 ```bash [npm]
-npm install @trpc/server@next @trpc/client@next trpc-nuxt zod
+npm install @trpc/server @trpc/client trpc-nuxt zod
 ```
 
 ```bash [yarn]
-yarn add @trpc/server@next @trpc/client@next trpc-nuxt zod
+yarn add @trpc/server @trpc/client trpc-nuxt zod
 ```
 
 ::


### PR DESCRIPTION
`@trpc/server` and `@trpc/client` are now pointing to v10, while the `next` tag is deprecated