### PR TITLE
docs: Add missed import in code sample

### DIFF
--- a/docs/content/1.get-started/2.usage.md
+++ b/docs/content/1.get-started/2.usage.md
@@ -107,6 +107,7 @@ Create a strongly-typed plugin using your API's type signature.
 ```ts [plugins/client.ts]
 import { httpBatchLink, createTRPCProxyClient } from '@trpc/client'
 import type { AppRouter } from '@/server/trpc/routers'
+import { FetchError } from 'ofetch'
 
 export default defineNuxtPlugin(() => {
   const client = createTRPCProxyClient<AppRouter>({


### PR DESCRIPTION
It's important to import `FetchError` from `ofetch`, not from `ohmyfetch`