### PR TITLE
fix: pass all arguments to proxied trpc client method

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -61,7 +61,7 @@ export function createNuxtProxyDecoration<TRouter extends AnyRouter> (name: stri
       }), asyncDataOptions)
     }
 
-    return (client as any)[path][lastArg](input)
+    return (client as any)[path][lastArg](...args)
   })
 }
 


### PR DESCRIPTION
This pull request fixes a bug in the `createNuxtProxyDecoration` function, which only passes the first argument to the proxied trpc client method. This causes some client methods like `subscribe` to fail because they expect more than `input` argument.