### PR TITLE
Correct plugin code in recommended docs

### DIFF
--- a/docs/content/1.get-started/2.usage/2.recommended.md
+++ b/docs/content/1.get-started/2.usage/2.recommended.md
@@ -123,7 +123,7 @@ export default defineNuxtPlugin(() => {
   const client = createTRPCNuxtClient<AppRouter>({
     links: [
       httpBatchLink({
-        url: '/api/trpc',
+        url: '/api/',
       }),
     ],
   })


### PR DESCRIPTION
Since the api (`/api/[trpc].ts`) is using dynamic route parameters (https://nuxt.com/docs/guide/directory-structure/pages/), the base path for the client needs to just be `/api/` to use the correct path.