### PR TITLE
feat: useMutation composable

### DIFF
--- a/docs/content/1.get-started/3.client.md
+++ b/docs/content/1.get-started/3.client.md
@@ -49,7 +49,7 @@ const getUser = await $client.getUser.useQuery('id_bilbo');
 
 const createUser = await $client.createUser.useMutation();
 await createUser.mutate({ name: 'Frodo' });
-// => { data: { id: 'id_frodo', name: 'Frodo' }, pending: false, error: false };
+// => { id: 'id_frodo', name: 'Frodo' };
 
 
 // With vanilla

--- a/docs/content/1.get-started/3.client.md
+++ b/docs/content/1.get-started/3.client.md
@@ -42,11 +42,21 @@ As you can see, we passed `AppRouter` as a type argument of `createTRPCNuxtClien
 <script setup lang="ts">
 const { $client } = useNuxtApp()
 
+// With composables
+
 const getUser = await $client.getUser.useQuery('id_bilbo');
 // => { data: { id: 'id_bilbo', name: 'Bilbo' }, pending: false, error: false };
 
+const createUser = await $client.createUser.useMutation();
+await createUser.mutate({ name: 'Frodo' });
+// => { data: { id: 'id_frodo', name: 'Frodo' }, pending: false, error: false };
+
+
+// With vanilla
+
 const bilbo = await $client.getUser.query('id_bilbo');
 // => { id: 'id_bilbo', name: 'Bilbo' };
+
 const frodo = await $client.createUser.mutate({ name: 'Frodo' });
 // => { id: 'id_frodo', name: 'Frodo' };
 </script>

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -8,20 +8,23 @@ const { data } = useNuxtData(todosKey)
 
 const { data: todos, pending, error, refresh } = await $client.todo.getTodos.useQuery()
 
+const { mutate } = $client.todo.addTodo.useMutation()
+
 const addTodo = async () => {
   const title = Math.random().toString(36).slice(2, 7)
+
   const newData = {
     id: Date.now(),
     userId: 69,
     title,
     completed: false
   }
+
   data.value.push(newData)
-  try {
-    const x = await $client.todo.addTodo.mutate(newData)
-  } catch (e) {
-    console.log(e)
-  }
+
+  await mutate(newData)
+
+  await refreshNuxtData(todosKey)
 }
 </script>
 

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -20,11 +20,9 @@ const addTodo = async () => {
     completed: false
   }
 
-  data.value.push(newData)
+  const result = await mutate(newData)
 
-  await mutate(newData)
-
-  await refreshNuxtData(todosKey)
+  data.value.push(result)
 }
 </script>
 

--- a/src/client/decorationProxy.ts
+++ b/src/client/decorationProxy.ts
@@ -2,7 +2,7 @@ import { type inferRouterProxyClient } from '@trpc/client'
 import { type AnyRouter } from '@trpc/server'
 import { createRecursiveProxy } from '@trpc/server/shared'
 // @ts-expect-error: Nuxt auto-imports
-import { getCurrentInstance, onScopeDispose, useAsyncData, unref, isRef } from '#imports'
+import { getCurrentInstance, onScopeDispose, useAsyncData, unref, ref, isRef, toRaw } from '#imports'
 import { getQueryKeyInternal } from './getQueryKey'
 
 export function createNuxtProxyDecoration<TRouter extends AnyRouter> (name: string, client: inferRouterProxyClient<TRouter>) {
@@ -51,6 +51,43 @@ export function createNuxtProxyDecoration<TRouter extends AnyRouter> (name: stri
         watch,
         lazy: isLazy
       })
+    }
+
+    if (lastArg === 'useMutation') {
+      const { trpc, queryKey: customQueryKey, ...asyncDataOptions } = otherOptions || {} as any
+      // Payload will be set by the `mutate` function and used by `useAsyncData`.
+      const payload = ref(null)
+
+      let controller: AbortController
+
+      if (trpc?.abortOnUnmount) {
+        if (getCurrentInstance()) {
+          onScopeDispose(() => {
+            controller?.abort?.()
+          })
+        }
+        controller = typeof AbortController !== 'undefined' ? new AbortController() : {} as AbortController
+      }
+  
+      const asyncData = useAsyncData(() => (client as any)[path].mutate(payload.value, {
+        signal: controller?.signal,
+        ...trpc
+      }), {
+        ...asyncDataOptions,
+        immediate: false
+      })
+
+      // eslint-disable-next-line no-inner-declarations
+      async function mutate (input: any) {
+        payload.value = input
+        await asyncData.execute()
+        return toRaw(asyncData.data.value)
+      }
+
+      return {
+        mutate,
+        ...asyncData
+      }
     }
     
     return (client as any)[path][lastArg](...args)

--- a/src/client/decorationProxy.ts
+++ b/src/client/decorationProxy.ts
@@ -68,8 +68,10 @@ export function createNuxtProxyDecoration<TRouter extends AnyRouter> (name: stri
         }
         controller = typeof AbortController !== 'undefined' ? new AbortController() : {} as AbortController
       }
+
+      const queryKey = customQueryKey || getQueryKeyInternal(path, undefined)
   
-      const asyncData = useAsyncData(() => (client as any)[path].mutate(payload.value, {
+      const asyncData = useAsyncData(queryKey, () => (client as any)[path].mutate(payload.value, {
         signal: controller?.signal,
         ...trpc
       }), {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -19,7 +19,7 @@ import type {
   KeysOf,
   PickFrom,
 } from 'nuxt/dist/app/composables/asyncData'
-import type { Ref } from 'vue'
+import type { Ref, UnwrapRef } from 'vue'
 
 interface TRPCRequestOptions extends _TRPCRequestOptions {
   abortOnUnmount?: boolean
@@ -96,7 +96,7 @@ export type DecorateProcedure<
         opts?: Omit<AsyncDataOptions<ResT, DataT, PickKeys>, 'lazy'> & {
           trpc?: TRPCRequestOptions
         },
-      ) => AsyncData<PickFrom<DataT, PickKeys> | null, DataE> & { mutate: (input: inferProcedureInput<TProcedure>) => Promise<AsyncData<PickFrom<DataT, PickKeys> | null, DataE>['data']> },
+      ) => AsyncData<PickFrom<DataT, PickKeys> | null, DataE> & { mutate: (input: inferProcedureInput<TProcedure>) => Promise<UnwrapRef<AsyncData<PickFrom<DataT, PickKeys> | null, DataE>['data']>> },
     } : TProcedure extends AnySubscriptionProcedure ? {
       subscribe: SubscriptionResolver<TProcedure, TRouter>
     } : never

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -87,6 +87,16 @@ export type DecorateProcedure<
       query: Resolver<TProcedure>
     } : TProcedure extends AnyMutationProcedure ? {
       mutate: Resolver<TProcedure>
+      useMutation: <
+        ResT = inferTransformedProcedureOutput<TProcedure>,
+        DataE = TRPCClientErrorLike<TProcedure>,
+        DataT = ResT,
+        PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
+     >(
+        opts?: Omit<AsyncDataOptions<ResT, DataT, PickKeys>, 'lazy'> & {
+          trpc?: TRPCRequestOptions
+        },
+      ) => AsyncData<PickFrom<DataT, PickKeys> | null, DataE> & { mutate: (input: inferProcedureInput<TProcedure>) => Promise<AsyncData<PickFrom<DataT, PickKeys> | null, DataE>['data']> },
     } : TProcedure extends AnySubscriptionProcedure ? {
       subscribe: SubscriptionResolver<TProcedure, TRouter>
     } : never


### PR DESCRIPTION
This PR adds a `useMutation` composable kinda similar to TanStack Query [useMutation](https://trpc.io/docs/client/react/useMutation):

```vue
<script setup lang="ts">
const { $client } = useNuxtApp()

const { mutate, pending, error } = $client.login.useMutation()

const handleLogin = () => {
  const name = 'John Doe';
  mutate({ name });
}
</script>

<template>
  <h1>Login Form</h1>
  <button
    :disabled="pending"
    @click="handleLogin"
  >
    Login
  </button>
  <div v-if="error">
    Something went wrong
  </div>
</template>
```

Needs improvement but it works for now!
