### PR TITLE
fix: typings when using moduleResolution: "bundler"/"node16"

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,18 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "types": {
+        "require": "./dist/index.d.cts",
+        "import": "./dist/index.d.ts"
+      },
       "require": "./dist/index.cjs",
       "import": "./dist/index.mjs"
     },
     "./client": {
-      "types": "./dist/client/index.d.ts",
+      "types": {
+        "require": "./dist/client/index.d.cts",
+        "import": "./dist/client/index.d.ts"
+      },
       "require": "./dist/client/index.cjs",
       "import": "./dist/client/index.mjs"
     }

--- a/src/client/links.ts
+++ b/src/client/links.ts
@@ -1,11 +1,9 @@
-import { httpLink as _httpLink, httpBatchLink as _httpBatchLink } from '@trpc/client'
+import { httpLink as _httpLink, httpBatchLink as _httpBatchLink, type HTTPLinkOptions as _HTTPLinkOptions, type HTTPBatchLinkOptions as _HTTPBatchLinkOptions } from '@trpc/client'
+import { type FetchEsque } from '@trpc/client/dist/internals/types'
 import { type AnyRouter } from '@trpc/server'
 import { FetchError } from 'ofetch'
 // @ts-expect-error: Nuxt auto-imports
 import { useRequestHeaders } from '#imports'
-import { type HTTPLinkOptions as _HTTPLinkOptions } from '@trpc/client/dist/links/httpLink'
-import { type HTTPBatchLinkOptions as _HTTPBatchLinkOptions } from '@trpc/client/dist/links/HTTPBatchLinkOptions';
-import { type FetchEsque } from '@trpc/client/dist/internals/types'
 
 function customFetch(input: RequestInfo | URL, init?: RequestInit & { method: 'GET' })  {
   return globalThis.$fetch.raw(input.toString(), init)

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -13,12 +13,8 @@ import type {
 } from '@trpc/server'
 import { type inferObservableValue, type Unsubscribable } from '@trpc/server/observable'
 import { inferTransformedProcedureOutput } from '@trpc/server/shared'
-import type {
-  AsyncData,
-  AsyncDataOptions,
-  KeysOf,
-  PickFrom,
-} from 'nuxt/dist/app/composables/asyncData'
+import type { AsyncData, AsyncDataOptions } from 'nuxt/app'
+import type { KeysOf, PickFrom } from 'nuxt/dist/app/composables/asyncData'
 import type { Ref, UnwrapRef } from 'vue'
 
 interface TRPCRequestOptions extends _TRPCRequestOptions {


### PR DESCRIPTION
This isn't a perfect fix as `@trpc/client/dist/internals/types` and `nuxt/dist/app/composables/asyncData` still can't be resolved when using `moduleResolution: "bundler"` (as they aren't publicly exported by their respective package).