### PR TITLE
Fix deprecated imports

### DIFF
--- a/src/client/decorationProxy.ts
+++ b/src/client/decorationProxy.ts
@@ -1,6 +1,5 @@
 import { type inferRouterProxyClient } from '@trpc/client'
-import { type AnyRouter } from '@trpc/server'
-import { createRecursiveProxy } from '@trpc/server/shared'
+import { createRecursiveProxy, type AnyRouter } from '@trpc/core'
 // @ts-expect-error: Nuxt auto-imports
 import { getCurrentInstance, onScopeDispose, useAsyncData, unref, ref, isRef, toRaw } from '#imports'
 import { getQueryKeyInternal } from './getQueryKey'

--- a/src/client/getQueryKey.ts
+++ b/src/client/getQueryKey.ts
@@ -3,7 +3,7 @@ import {
   AnyRouter,
   DeepPartial,
   inferProcedureInput,
-} from '@trpc/server';
+} from '@trpc/core';
 import { hash } from 'ohash'
 import { DecorateProcedure } from './types';
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,6 +1,5 @@
-import { type CreateTRPCClientOptions, createTRPCProxyClient } from '@trpc/client'
-import { type AnyRouter } from '@trpc/server'
-import { createFlatProxy } from '@trpc/server/shared'
+import { createTRPCProxyClient, type CreateTRPCClientOptions } from '@trpc/client'
+import { createFlatProxy, type AnyRouter } from '@trpc/core'
 import { type DecoratedProcedureRecord } from './types'
 import { getQueryKey } from './getQueryKey'
 import { createNuxtProxyDecoration } from './decorationProxy'

--- a/src/client/links.ts
+++ b/src/client/links.ts
@@ -1,5 +1,5 @@
 import { httpLink as _httpLink, httpBatchLink as _httpBatchLink } from '@trpc/client'
-import { type AnyRouter } from '@trpc/server'
+import { type AnyRouter } from '@trpc/core'
 import { FetchError } from 'ofetch'
 // @ts-expect-error: Nuxt auto-imports
 import { useRequestHeaders } from '#imports'

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -10,9 +10,9 @@ import type {
   inferProcedureOutput,
   ProcedureArgs,
   AnySubscriptionProcedure
-} from '@trpc/server'
+} from '@trpc/core'
 import { type inferObservableValue, type Unsubscribable } from '@trpc/server/observable'
-import { inferTransformedProcedureOutput } from '@trpc/server/shared'
+import { inferTransformedProcedureOutput } from '@trpc/core'
 import type {
   AsyncData,
   AsyncDataOptions,


### PR DESCRIPTION
Use the new [`@trpc/core`](https://trpc.io/docs/migrate-from-v10-to-v11#added-a-trpccore-package) package