### PR TITLE
Stop relying on internal types of trpc and nuxt

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,5 +1,4 @@
 import type { TRPCClientErrorLike, TRPCRequestOptions as _TRPCRequestOptions } from '@trpc/client'
-import { type TRPCSubscriptionObserver } from '@trpc/client/dist/internals/TRPCUntypedClient'
 import type {
   AnyMutationProcedure,
   AnyProcedure,
@@ -13,9 +12,19 @@ import type {
 } from '@trpc/server'
 import { type inferObservableValue, type Unsubscribable } from '@trpc/server/observable'
 import { inferTransformedProcedureOutput } from '@trpc/server/shared'
-import type { KeysOf, PickFrom } from 'nuxt/dist/app/composables/asyncData'
 import type { AsyncData, AsyncDataOptions } from 'nuxt/app'
 import type { Ref, UnwrapRef } from 'vue'
+
+type PickFrom<T, K extends Array<string>> = T extends Array<any> ? T : T extends Record<string, any> ? keyof T extends K[number] ? T : K[number] extends never ? T : Pick<T, K[number]> : T;
+type KeysOf<T> = Array<T extends T ? keyof T extends string ? keyof T : never : never>;
+
+type TRPCSubscriptionObserver<TValue, TError> = {
+  onStarted: () => void;
+  onData: (value: TValue) => void;
+  onError: (err: TError) => void;
+  onStopped: () => void;
+  onComplete: () => void;
+}
 
 interface TRPCRequestOptions extends _TRPCRequestOptions {
   abortOnUnmount?: boolean


### PR DESCRIPTION
# Why?

Usage of internal types was a massive headache for me for last 4 hours. In some of my project typescript decides to respect "exports" field in package.json, and internal types become `any`. So data field in `useQuery()` also became `any` and i broke the prod. 