### PR TITLE
feat: allow getter inputs

### DIFF
--- a/src/client/decorationProxy.ts
+++ b/src/client/decorationProxy.ts
@@ -2,7 +2,7 @@ import { type inferRouterProxyClient } from '@trpc/client'
 import { type AnyRouter } from '@trpc/server'
 import { createRecursiveProxy } from '@trpc/server/shared'
 // @ts-expect-error: Nuxt auto-imports
-import { getCurrentInstance, onScopeDispose, useAsyncData, unref, ref, isRef, toRaw } from '#imports'
+import { getCurrentInstance, onScopeDispose, useAsyncData, toValue, ref, isRef, toRaw } from '#imports'
 import { getQueryKeyInternal } from './getQueryKey'
 
 function createAbortController(trpc: any) {
@@ -45,11 +45,11 @@ export function createNuxtProxyDecoration<TRouter extends AnyRouter> (name: stri
 
       const controller = createAbortController(trpc);
 
-      const queryKey = customQueryKey || getQueryKeyInternal(path, unref(input))
+      const queryKey = customQueryKey || getQueryKeyInternal(path, toValue(input))
       const watch = isRef(input) ? [...(asyncDataOptions.watch || []), input] : asyncDataOptions.watch
       const isLazy = lastArg === 'useLazyQuery' ? true : (asyncDataOptions.lazy || false)
   
-      return useAsyncData(queryKey, () => (client as any)[path].query(unref(input), {
+      return useAsyncData(queryKey, () => (client as any)[path].query(toValue(input), {
         signal: controller?.signal,
         ...trpc
       }), {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -13,7 +13,7 @@ import type {
 import { type inferObservableValue, type Unsubscribable } from '@trpc/server/observable'
 import { inferTransformedProcedureOutput } from '@trpc/server/shared'
 import type { AsyncData, AsyncDataOptions } from 'nuxt/app'
-import type { Ref, UnwrapRef } from 'vue'
+import type { MaybeRefOrGetter, UnwrapRef } from 'vue'
 
 type PickFrom<T, K extends Array<string>> = T extends Array<any> ? T : T extends Record<string, any> ? keyof T extends K[number] ? T : K[number] extends never ? T : Pick<T, K[number]> : T;
 type KeysOf<T> = Array<T extends T ? keyof T extends string ? keyof T : never : never>;
@@ -50,8 +50,6 @@ type SubscriptionResolver<
   ]
 ) => Unsubscribable
 
-type MaybeRef<T> = T | Ref<T>
-
 export type DecorateProcedure<
   TProcedure extends AnyProcedure,
   TRouter extends AnyRouter,
@@ -63,7 +61,7 @@ export type DecorateProcedure<
         DataT = ResT,
         PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
      >(
-        input: MaybeRef<inferProcedureInput<TProcedure>>,
+        input: MaybeRefOrGetter<inferProcedureInput<TProcedure>>,
         opts?: AsyncDataOptions<ResT, DataT, PickKeys> & {
           trpc?: TRPCRequestOptions
           /**
@@ -79,7 +77,7 @@ export type DecorateProcedure<
         DataT = ResT,
         PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
      >(
-        input: MaybeRef<inferProcedureInput<TProcedure>>,
+        input: MaybeRefOrGetter<inferProcedureInput<TProcedure>>,
         opts?: Omit<AsyncDataOptions<ResT, DataT, PickKeys>, 'lazy'> & {
           trpc?: TRPCRequestOptions
           /**


### PR DESCRIPTION
This PR allows the passing of getters as inputs in queries. Closes https://github.com/wobsoriano/trpc-nuxt/issues/147.

To make a query auto-refetch on input update, you'll have to pass a `ref` or `computed`:

```ts
const id = ref(1)
$client.todo.getTodo.useQuery(id)

const anotherId = computed(() => id.value + 1)
$client.todo.getTodo.useQuery(anotherId)
```

If you have an object as input, you can do any of the ff. to re-execute a query:

1. Wrap the object in a computed property:

```ts
// This will re-execute the query if any of the following refs updates
const field = ref('someField')
const input = ref('foo')

const payload = computed(() => ({ field: field.value, value: input.value }))
$client.user.searchUser.useQuery(payload)
```

2. Convert the input to a getter and pass the refs to the `watch` option:

```ts
const field = ref('someField')
const input = ref('foo')

$client.user.searchUser.useQuery(() => ({
  field: field.value,
  value: input.value
}), {
  // For getter inputs, we still need to pass the refs/computed to the `watch` property to make it reactive.
  watch: [field, input]
})
```