### PR TITLE
fix: fetch error detection

### DIFF
--- a/src/client/links.ts
+++ b/src/client/links.ts
@@ -12,7 +12,7 @@ import { type FetchEsque } from '@trpc/client/dist/internals/types'
 function customFetch(input: RequestInfo | URL, init?: RequestInit & { method: 'GET' })  {
   return globalThis.$fetch.raw(input.toString(), init)
     .catch((e) => {
-      if (e.constructor.name === 'FetchError' && e.response) { return e.response }
+      if (e instanceof Error && e.name === 'FetchError' && e.response) { return e.response }
       throw e
     })
     .then(response => ({


### PR DESCRIPTION
When building to production, error.constructor.name comes from name of the class, witch gets mangled

![image](https://github.com/wobsoriano/trpc-nuxt/assets/29816814/78fff57d-aa68-451c-be79-b95986557620)

Better to check on object itself, cause FetchError in constructor sets name.
![image](https://github.com/wobsoriano/trpc-nuxt/assets/29816814/60c3a885-2511-439d-a6df-f965880bf8b3)

Appreciate if you release this fix asap, bit me in production