### PR TITLE
feat: allow advanced response handling on server & client

### DIFF
--- a/.changeset/floppy-dingos-lose.md
+++ b/.changeset/floppy-dingos-lose.md
@@ -1,0 +1,9 @@
+---
+"trpc-nuxt": minor
+---
+
+Allow advanced response handling on server & client.
+
+It's now possible to handle the h3 event with e.g. `sendRedirect()` inside of a tRPC procedure, like you would inside a Nitro event handler.
+
+`http*Link()` adapters now have a `fetchOptions` parameter, allowing to pass options to the `ofetch` instance used internally. This can be useful for intercepting requests/responses on the client side.

--- a/src/server/createTRPCNuxtHandler.ts
+++ b/src/server/createTRPCNuxtHandler.ts
@@ -44,6 +44,10 @@ export function createTRPCNuxtHandler<TRouter extends AnyTRPCRouter>(opts: TRPCN
       createContext,
     });
 
+    // don't return tRPC response when h3 event was already handled (e.g. using sendRedirect() or sendStream())
+    if (event.handled)
+      return;
+
     return httpResponse;
   });
 }


### PR DESCRIPTION
Hi Robert, thank you for this library!
We are using it extensively and had to add some logic to it, which we would like to get from upstream.

These changes allow handling events in the tRPC route using h3 directly (e.g. sendRedirect, sendStream) and reading the response on the client-side to access for example, its headers.