### PR TITLE
fix(client): import AsyncData types from nuxt/app instead of #imports

### DIFF
--- a/src/client/create-trpc-nuxt-client.ts
+++ b/src/client/create-trpc-nuxt-client.ts
@@ -1,4 +1,4 @@
-import type { AsyncData, AsyncDataOptions } from '#imports';
+import type { AsyncData, AsyncDataOptions } from 'nuxt/app';
 import type {
   CreateTRPCClientOptions,
   OperationContext,

--- a/src/client/decoration-proxy.ts
+++ b/src/client/decoration-proxy.ts
@@ -1,5 +1,5 @@
 import { useAsyncData } from '#imports';
-import type { AsyncDataOptions } from '#imports';
+import type { AsyncDataOptions } from 'nuxt/app';
 import type { TRPCClient, TRPCRequestOptions } from '@trpc/client';
 import type { TRPCConnectionState } from '@trpc/client/unstable-internals';
 import type { AnyTRPCRouter } from '@trpc/server';


### PR DESCRIPTION
## Problem

Fixes #255.

Since 2.1.0, `useQuery()` / `useMutation()` return types collapse to `any` — `data` / `data.value` lose all inference, so `.map()` / `.find()` / property access over query results becomes implicitly `any`.

## Root cause

The client source imports the `AsyncData` / `AsyncDataOptions` **types** from `#imports`:

- `src/client/create-trpc-nuxt-client.ts`
- `src/client/decoration-proxy.ts`

The package ships an ambient `declare module '#imports'` (`src/runtime/types/nuxt-imports.d.ts`) that re-exports those types from `nuxt/app`, which is why it type-checks during the package's own build. But that ambient declaration is **not active in a consumer's context** — there, `#imports` resolves to Nuxt's real generated virtual module, which does **not** re-export `AsyncData` / `AsyncDataOptions` as types. So in the shipped `dist/client/index.d.mts` the `AsyncData<…>` return type resolves to nothing and degrades to `any`, taking `data` / `data.value` with it.

This regressed in 2.1.0 (`#imports` migration). In 2.0.x these types were imported from `nuxt/app` and inference worked.

## Fix

Import the **types** from `nuxt/app` directly (runtime `useAsyncData` value import stays on `#imports`). After building, `dist/client/index.d.mts` now emits:

```ts
import { AsyncData, AsyncDataOptions } from "nuxt/app";
```

which restores full inference on `useQuery`/`useMutation` results.

## Notes

- Type-only change; no runtime behavior change.
- Confirmed downstream: pinning a real Nuxt 4 app to 2.0.1 (which imports these types from `nuxt/app`) took a package from 37 → 0 `implicit any` type errors with zero call-site changes; this PR brings 2.1.x back to that behavior.
- Minimal repro: a 2-field router with an array-returning query — `const { data } = await client.list.useQuery(); data.value?.map(r => r.id)` types `r` as `any` on 2.1.x, correctly on 2.0.x / with this fix.