### PR TITLE
chore: stop shipping type imports from #imports, add type regression guard

### DIFF
--- a/.changeset/tidy-moons-repeat.md
+++ b/.changeset/tidy-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'trpc-nuxt': patch
+---
+
+Fix `useQuery` / `useMutation` return types collapsing to `any` (regression in 2.1.0).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Build library
         run: vp run build:lib
 
+      - name: Typecheck published declarations
+        run: vp run test:types
+
       - name: Install Playwright browsers
         working-directory: apps/test
         run: vp exec playwright install --with-deps

--- a/apps/test/package.json
+++ b/apps/test/package.json
@@ -8,7 +8,8 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "test": "playwright test"
+    "test": "playwright test",
+    "test:types": "vp test"
   },
   "dependencies": {
     "@trpc/client": "catalog:trpc",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@nuxt/test-utils": "^4.0.3",
-    "@playwright/test": "1.60.0"
+    "@playwright/test": "1.60.0",
+    "vitest": "catalog:"
   }
 }

--- a/apps/test/test-types/inference.test-d.ts
+++ b/apps/test/test-types/inference.test-d.ts
@@ -1,17 +1,5 @@
-// Type-level regression guard for the *published* declarations.
-//
-// This consumes `trpc-nuxt/client` the way a real app does, so it typechecks
-// `dist/**/*.d.mts` rather than `src`. Nuxt sets `skipLibCheck: true` by
-// default, so a broken import inside our shipped `.d.mts` does not error, it
-// silently resolves to `any` and takes `data` / `data.value` with it.
-//
-// NOTE: `toEqualTypeOf` does NOT catch that failure. When a module in a `.d.mts`
-// cannot be resolved, TS produces its *error* type, which is mutually assignable
-// with everything and short-circuits the conditional types `toEqualTypeOf` is
-// built on, so it reports a false pass. `not.toBeAny()` and `@ts-expect-error`
-// both catch it. Keep at least one of those per assertion group.
-//
-// See https://github.com/wobsoriano/trpc-nuxt/issues/255
+// Typechecks a consumer against the built `dist`, not `src`.
+// @see https://github.com/wobsoriano/trpc-nuxt/issues/255
 
 import { createTRPCNuxtClient } from 'trpc-nuxt/client';
 import { assertType, describe, expectTypeOf, test } from 'vitest';
@@ -23,15 +11,14 @@ declare const client: ReturnType<typeof createTRPCNuxtClient<AppRouter>>;
 describe('useQuery', () => {
   const query = client.hello.useQuery({ text: 'world' });
 
-  test('data is inferred, not any', () => {
-    expectTypeOf(query.data).not.toBeAny();
+  test('data is inferred', () => {
+    // `toEqualTypeOf` alone passes here even when inference is broken: an
+    // unresolvable module in a `.d.mts` yields TS's error type, which satisfies it.
     expectTypeOf(query.data.value).not.toBeAny();
     expectTypeOf(query.data.value).toEqualTypeOf<{ greeting: string } | undefined>();
   });
 
   test('output shape is enforced', () => {
-    expectTypeOf(query.data.value?.greeting).toEqualTypeOf<string | undefined>();
-
     // @ts-expect-error `greeting` is a string, not a number.
     assertType<number | undefined>(query.data.value?.greeting);
 
@@ -53,8 +40,7 @@ describe('useQuery', () => {
 describe('useMutation', () => {
   const mutation = client.setCount.useMutation();
 
-  test('data is inferred, not any', () => {
-    expectTypeOf(mutation.data).not.toBeAny();
+  test('data is inferred', () => {
     expectTypeOf(mutation.data.value).not.toBeAny();
     expectTypeOf(mutation.data.value).toEqualTypeOf<number | undefined>();
   });

--- a/apps/test/test-types/inference.test-d.ts
+++ b/apps/test/test-types/inference.test-d.ts
@@ -1,0 +1,76 @@
+// Type-level regression guard for the *published* declarations.
+//
+// This consumes `trpc-nuxt/client` the way a real app does, so it typechecks
+// `dist/**/*.d.mts` rather than `src`. Nuxt sets `skipLibCheck: true` by
+// default, so a broken import inside our shipped `.d.mts` does not error, it
+// silently resolves to `any` and takes `data` / `data.value` with it.
+//
+// NOTE: `toEqualTypeOf` does NOT catch that failure. When a module in a `.d.mts`
+// cannot be resolved, TS produces its *error* type, which is mutually assignable
+// with everything and short-circuits the conditional types `toEqualTypeOf` is
+// built on, so it reports a false pass. `not.toBeAny()` and `@ts-expect-error`
+// both catch it. Keep at least one of those per assertion group.
+//
+// See https://github.com/wobsoriano/trpc-nuxt/issues/255
+
+import { createTRPCNuxtClient } from 'trpc-nuxt/client';
+import { assertType, describe, expectTypeOf, test } from 'vitest';
+
+import type { AppRouter } from '../server/trpc/routers';
+
+declare const client: ReturnType<typeof createTRPCNuxtClient<AppRouter>>;
+
+describe('useQuery', () => {
+  const query = client.hello.useQuery({ text: 'world' });
+
+  test('data is inferred, not any', () => {
+    expectTypeOf(query.data).not.toBeAny();
+    expectTypeOf(query.data.value).not.toBeAny();
+    expectTypeOf(query.data.value).toEqualTypeOf<{ greeting: string } | undefined>();
+  });
+
+  test('output shape is enforced', () => {
+    expectTypeOf(query.data.value?.greeting).toEqualTypeOf<string | undefined>();
+
+    // @ts-expect-error `greeting` is a string, not a number.
+    assertType<number | undefined>(query.data.value?.greeting);
+
+    // @ts-expect-error `nope` is not a property of the query output.
+    void query.data.value?.nope;
+  });
+
+  test('input shape is enforced', () => {
+    // @ts-expect-error `hello` takes `{ text: string }`, not a number.
+    void client.hello.useQuery(123);
+  });
+
+  test('direct resolver is inferred', () => {
+    expectTypeOf(client.hello.query).returns.resolves.not.toBeAny();
+    expectTypeOf(client.hello.query).returns.resolves.toEqualTypeOf<{ greeting: string }>();
+  });
+});
+
+describe('useMutation', () => {
+  const mutation = client.setCount.useMutation();
+
+  test('data is inferred, not any', () => {
+    expectTypeOf(mutation.data).not.toBeAny();
+    expectTypeOf(mutation.data.value).not.toBeAny();
+    expectTypeOf(mutation.data.value).toEqualTypeOf<number | undefined>();
+  });
+
+  test('output shape is enforced', () => {
+    // @ts-expect-error `setCount` returns a number, not a string.
+    assertType<string | undefined>(mutation.data.value);
+  });
+
+  test('input shape is enforced', () => {
+    // @ts-expect-error `setCount` takes a number, not a string.
+    void mutation.mutate('nope');
+  });
+
+  test('direct resolver is inferred', () => {
+    expectTypeOf(client.setCount.mutate).returns.resolves.not.toBeAny();
+    expectTypeOf(client.setCount.mutate).returns.resolves.toEqualTypeOf<number>();
+  });
+});

--- a/apps/test/test-types/tsconfig.json
+++ b/apps/test/test-types/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022", "dom"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": [],
+    "paths": {
+      "~/*": ["../app/*"],
+      "~~/*": ["../*"]
+    }
+  },
+  "include": ["./**/*.ts", "../server/trpc/**/*.ts"]
+}

--- a/apps/test/vitest.config.ts
+++ b/apps/test/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Playwright owns the runtime e2e suite, so this project is type tests only.
+    include: [],
+    typecheck: {
+      enabled: true,
+      only: true,
+      include: ['test-types/**/*.test-d.ts'],
+      tsconfig: './test-types/tsconfig.json',
+    },
+  },
+});

--- a/apps/test/vitest.config.ts
+++ b/apps/test/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    // Playwright owns the runtime e2e suite, so this project is type tests only.
+    // playwright owns the runtime suite, this project is type tests only
     include: [],
     typecheck: {
       enabled: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
         version: 1.15.11
       nuxt:
         specifier: catalog:repo
-        version: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)
+        version: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -111,7 +111,7 @@ importers:
         version: 22.12.0
       nuxt:
         specifier: catalog:repo
-        version: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)
+        version: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2)
 
   apps/test:
     dependencies:
@@ -123,7 +123,7 @@ importers:
         version: 11.17.0(typescript@5.9.3)
       nuxt:
         specifier: catalog:repo
-        version: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)
+        version: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2)
       superjson:
         specifier: catalog:repo
         version: 2.2.6
@@ -136,10 +136,13 @@ importers:
     devDependencies:
       '@nuxt/test-utils':
         specifier: ^4.0.3
-        version: 4.0.3(@playwright/test@1.60.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(magicast@0.5.2)(playwright-core@1.60.0)(typescript@5.9.3)
+        version: 4.0.3(@playwright/test@1.60.0)(@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2))(magicast@0.5.2)(playwright-core@1.60.0)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
+      vitest:
+        specifier: npm:@voidzero-dev/vite-plus-test@latest
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2)'
 
 packages:
 
@@ -1420,14 +1423,21 @@ packages:
     resolution: {integrity: sha512-0+S67blQakgeNqoKGozOUp5rQBrz2ynXZ2QIINXZPiafsD0YL0UogB9hAWc1S7k6VSNwKYC/N7MqT0V6IzpHkQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  '@oxc-project/runtime@0.133.0':
+    resolution: {integrity: sha512-PkvjA1Lq5++V5S1E6Patr92ZVcieE6EalDr1VJTqv4BnjZdOUC4W3p8k1wMXSd5/2aFP4b/A6N5sg2Bkzcr9vQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@oxc-project/types@0.128.0':
     resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
 
   '@oxc-project/types@0.129.0':
     resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
 
-  '@oxc-project/types@0.130.0':
-    resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@oxc-project/types@0.144.0':
+    resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
 
   '@oxc-transform/binding-android-arm-eabi@0.128.0':
     resolution: {integrity: sha512-qVO4izEs88ZSo7KOK4P+O5nAXXJmkSadInvFjGkhVnm2R2Wr8trU/GLhjAK0S0u8Qv9bkXspNhgpECk+CTQ/ew==}
@@ -1947,91 +1957,86 @@ packages:
   '@poppinss/exception@1.2.2':
     resolution: {integrity: sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==}
 
-  '@rolldown/binding-android-arm64@1.0.1':
-    resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
+  '@rolldown/binding-android-arm64@1.2.4':
+    resolution: {integrity: sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.1':
-    resolution: {integrity: sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==}
+  '@rolldown/binding-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.1':
-    resolution: {integrity: sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==}
+  '@rolldown/binding-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.1':
-    resolution: {integrity: sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==}
+  '@rolldown/binding-freebsd-x64@1.2.4':
+    resolution: {integrity: sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
-    resolution: {integrity: sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.4':
+    resolution: {integrity: sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.1':
-    resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.4':
+    resolution: {integrity: sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.1':
-    resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
+  '@rolldown/binding-linux-arm64-musl@1.2.4':
+    resolution: {integrity: sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
-    resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.4':
+    resolution: {integrity: sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.1':
-    resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.4':
+    resolution: {integrity: sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.1':
-    resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
+  '@rolldown/binding-linux-x64-gnu@1.2.4':
+    resolution: {integrity: sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.1':
-    resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
+  '@rolldown/binding-linux-x64-musl@1.2.4':
+    resolution: {integrity: sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.1':
-    resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
+  '@rolldown/binding-openharmony-arm64@1.2.4':
+    resolution: {integrity: sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.1':
-    resolution: {integrity: sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.1':
-    resolution: {integrity: sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.4':
+    resolution: {integrity: sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.1':
-    resolution: {integrity: sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==}
+  '@rolldown/binding-win32-x64-msvc@1.2.4':
+    resolution: {integrity: sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2466,6 +2471,69 @@ packages:
       yaml:
         optional: true
 
+  '@voidzero-dev/vite-plus-core@0.1.24':
+    resolution: {integrity: sha512-iXPGBABnQnrDMx89H6MOCGcTZp+QW+3rY4YMVKdE6ydchSvPk2O3MI2vgaRVfOtWJ2IjnxSnf1n2yjP67ZBRFQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@tsdown/css': 0.22.1
+      '@tsdown/exe': 0.22.1
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      publint: ^0.3.8
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      typescript: ^5.0.0 || ^6.0.0
+      unplugin-unused: ^0.5.0
+      unrun: '*'
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@tsdown/css':
+        optional: true
+      '@tsdown/exe':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      publint:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-unused:
+        optional: true
+      unrun:
+        optional: true
+      yaml:
+        optional: true
+
   '@voidzero-dev/vite-plus-darwin-arm64@0.1.22':
     resolution: {integrity: sha512-+6sRVGCAQSpO96WC0EZtSLJ01VzNiZL/eQUQ8NLVl1oH+0+KgHF2UXyqUXGCGf/JCu34egEwBEjDU3WUwN2mxg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2512,6 +2580,37 @@ packages:
       '@vitest/coverage-istanbul': 4.1.6
       '@vitest/coverage-v8': 4.1.6
       '@vitest/ui': 4.1.6
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  '@voidzero-dev/vite-plus-test@0.1.24':
+    resolution: {integrity: sha512-9NiG6UadG0iOaPL1AMsO5sDKkx6MADHw4/mMOmHWZUhhUwqzfVtnnptMK37vD71e6KyR7yAscx19FrtOWWtjvA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -4058,8 +4157,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -4070,8 +4181,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.32.0:
     resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -4082,8 +4205,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -4094,8 +4229,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -4106,8 +4253,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -4118,8 +4277,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
@@ -4472,6 +4641,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanotar@0.3.0:
     resolution: {integrity: sha512-Kv2JYYiCzt16Kt5QwAc9BFG89xfPNBx+oQL4GQXD9nLqPkZBiNaqaCWtwnbk/q7UVsTYevvM1b0UF8zmEI4pCg==}
 
@@ -4817,6 +4991,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -5028,6 +5206,10 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
@@ -5237,8 +5419,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rolldown@1.0.1:
-    resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
+  rolldown@1.2.4:
+    resolution: {integrity: sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -5600,6 +5782,10 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
@@ -5940,6 +6126,49 @@ packages:
     resolution: {integrity: sha512-fCCmEKjI+Hv74PdL/MKcrBkdYPHFNcqD5568KxwN0sa4SGxtcbs55i/577LxKs0w5zIjuLRZZ0zQPu9MO+9itg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vitefu@1.1.2:
     resolution: {integrity: sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==}
@@ -7162,19 +7391,11 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@2.7.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(magicast@0.5.2)':
+  '@nuxt/devtools-kit@2.7.0(magicast@0.5.2)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))':
     dependencies:
       '@nuxt/kit': 3.21.2(magicast@0.5.2)
       execa: 8.0.1
-      vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
-    transitivePeerDependencies:
-      - magicast
-
-  '@nuxt/devtools-kit@3.2.4(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(magicast@0.5.2)':
-    dependencies:
-      '@nuxt/kit': 4.4.5(magicast@0.5.2)
-      execa: 8.0.1
-      vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
+      vite: 8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - magicast
 
@@ -7183,6 +7404,22 @@ snapshots:
       '@nuxt/kit': 4.4.5(magicast@0.5.2)
       execa: 8.0.1
       vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
+    transitivePeerDependencies:
+      - magicast
+
+  '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))':
+    dependencies:
+      '@nuxt/kit': 4.4.5(magicast@0.5.2)
+      execa: 8.0.1
+      vite: 8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - magicast
+
+  '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))':
+    dependencies:
+      '@nuxt/kit': 4.4.5(magicast@0.5.2)
+      execa: 8.0.1
+      vite: 8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - magicast
 
@@ -7196,47 +7433,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.1
       semver: 7.8.0
-
-  '@nuxt/devtools@3.2.4(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      '@nuxt/devtools-kit': 3.2.4(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(magicast@0.5.2)
-      '@nuxt/devtools-wizard': 3.2.4
-      '@nuxt/kit': 4.4.5(magicast@0.5.2)
-      '@vue/devtools-core': 8.1.0(vue@3.5.34(typescript@5.9.3))
-      '@vue/devtools-kit': 8.1.2
-      birpc: 4.0.0
-      consola: 3.4.2
-      destr: 2.0.5
-      error-stack-parser-es: 1.0.5
-      execa: 8.0.1
-      fast-npm-meta: 1.4.2
-      get-port-please: 3.2.0
-      hookable: 6.1.1
-      image-meta: 0.2.2
-      is-installed-globally: 1.0.0
-      launch-editor: 2.13.1
-      local-pkg: 1.1.2
-      magicast: 0.5.2
-      nypm: 0.6.6
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      pkg-types: 2.3.1
-      semver: 7.8.0
-      simple-git: 3.33.0
-      sirv: 3.0.2
-      structured-clone-es: 2.0.0
-      tinyglobby: 0.2.16
-      vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.5(magicast@0.5.2))(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))
-      vite-plugin-vue-tracer: 1.4.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))
-      which: 6.0.1
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - vue
 
   '@nuxt/devtools@3.2.4(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
@@ -7271,6 +7467,88 @@ snapshots:
       vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
       vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.5(magicast@0.5.2))(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))
       vite-plugin-vue-tracer: 1.4.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))
+      which: 6.0.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - vue
+
+  '@nuxt/devtools@3.2.4(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))':
+    dependencies:
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))
+      '@nuxt/devtools-wizard': 3.2.4
+      '@nuxt/kit': 4.4.5(magicast@0.5.2)
+      '@vue/devtools-core': 8.1.0(vue@3.5.34(typescript@5.9.3))
+      '@vue/devtools-kit': 8.1.2
+      birpc: 4.0.0
+      consola: 3.4.2
+      destr: 2.0.5
+      error-stack-parser-es: 1.0.5
+      execa: 8.0.1
+      fast-npm-meta: 1.4.2
+      get-port-please: 3.2.0
+      hookable: 6.1.1
+      image-meta: 0.2.2
+      is-installed-globally: 1.0.0
+      launch-editor: 2.13.1
+      local-pkg: 1.1.2
+      magicast: 0.5.2
+      nypm: 0.6.6
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      semver: 7.8.0
+      simple-git: 3.33.0
+      sirv: 3.0.2
+      structured-clone-es: 2.0.0
+      tinyglobby: 0.2.16
+      vite: 8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.5(magicast@0.5.2))(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))
+      vite-plugin-vue-tracer: 1.4.0(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))
+      which: 6.0.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - vue
+
+  '@nuxt/devtools@3.2.4(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))':
+    dependencies:
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))
+      '@nuxt/devtools-wizard': 3.2.4
+      '@nuxt/kit': 4.4.5(magicast@0.5.2)
+      '@vue/devtools-core': 8.1.0(vue@3.5.34(typescript@5.9.3))
+      '@vue/devtools-kit': 8.1.2
+      birpc: 4.0.0
+      consola: 3.4.2
+      destr: 2.0.5
+      error-stack-parser-es: 1.0.5
+      execa: 8.0.1
+      fast-npm-meta: 1.4.2
+      get-port-please: 3.2.0
+      hookable: 6.1.1
+      image-meta: 0.2.2
+      is-installed-globally: 1.0.0
+      launch-editor: 2.13.1
+      local-pkg: 1.1.2
+      magicast: 0.5.2
+      nypm: 0.6.6
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      semver: 7.8.0
+      simple-git: 3.33.0
+      sirv: 3.0.2
+      structured-clone-es: 2.0.0
+      tinyglobby: 0.2.16
+      vite: 8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.5(magicast@0.5.2))(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))
+      vite-plugin-vue-tracer: 1.4.0(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))
       which: 6.0.1
       ws: 8.19.0
     transitivePeerDependencies:
@@ -7330,7 +7608,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.5(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(oxc-parser@0.128.0)(rolldown@1.0.1)(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.4.5(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2))(oxc-parser@0.128.0)(rolldown@1.2.4)(typescript@5.9.3)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -7348,8 +7626,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@netlify/blobs@9.1.2)(oxc-parser@0.128.0)(rolldown@1.0.1)
-      nuxt: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)
+      nitropack: 2.13.4(@netlify/blobs@9.1.2)(oxc-parser@0.128.0)(rolldown@1.2.4)
+      nuxt: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -7396,7 +7674,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.5(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(oxc-parser@0.128.0)(rolldown@1.0.1)(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.4.5(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(oxc-parser@0.128.0)(rolldown@1.2.4)(typescript@5.9.3)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -7414,8 +7692,74 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@netlify/blobs@9.1.2)(oxc-parser@0.128.0)(rolldown@1.0.1)
-      nuxt: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)
+      nitropack: 2.13.4(@netlify/blobs@9.1.2)(oxc-parser@0.128.0)(rolldown@1.2.4)
+      nuxt: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)
+      nypm: 0.6.6
+      ohash: 2.0.11
+      pathe: 2.0.3
+      rou3: 0.8.1
+      std-env: 4.1.0
+      ufo: 1.6.4
+      unctx: 2.5.0
+      unstorage: 1.17.5(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.1)
+      vue: 3.5.34(typescript@5.9.3)
+      vue-bundle-renderer: 2.2.0
+      vue-devtools-stub: 0.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - better-sqlite3
+      - db0
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - ioredis
+      - magicast
+      - mysql2
+      - oxc-parser
+      - rolldown
+      - sqlite3
+      - supports-color
+      - typescript
+      - uploadthing
+      - xml2js
+
+  '@nuxt/nitro-server@4.4.5(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2))(oxc-parser@0.128.0)(rolldown@1.2.4)(typescript@5.9.3)':
+    dependencies:
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.4.5(magicast@0.5.2)
+      '@unhead/vue': 2.1.15(vue@3.5.34(typescript@5.9.3))
+      '@vue/shared': 3.5.34
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      devalue: 5.8.1
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      h3: 1.15.11
+      impound: 1.1.5
+      klona: 2.0.6
+      mocked-exports: 0.1.1
+      nitropack: 2.13.4(@netlify/blobs@9.1.2)(oxc-parser@0.128.0)(rolldown@1.2.4)
+      nuxt: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -7479,10 +7823,10 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/test-utils@4.0.3(@playwright/test@1.60.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(magicast@0.5.2)(playwright-core@1.60.0)(typescript@5.9.3)':
+  '@nuxt/test-utils@4.0.3(@playwright/test@1.60.0)(@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2))(magicast@0.5.2)(playwright-core@1.60.0)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))':
     dependencies:
       '@clack/prompts': 1.2.0
-      '@nuxt/devtools-kit': 2.7.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(magicast@0.5.2)
+      '@nuxt/devtools-kit': 2.7.0(magicast@0.5.2)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))
       '@nuxt/kit': 3.21.2(magicast@0.5.2)
       c12: 3.3.4(magicast@0.5.2)
       consola: 3.4.2
@@ -7508,18 +7852,19 @@ snapshots:
       tinyexec: 1.1.2
       ufo: 1.6.4
       unplugin: 3.0.0
-      vitest-environment-nuxt: 2.0.0(@playwright/test@1.60.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(magicast@0.5.2)(playwright-core@1.60.0)(typescript@5.9.3)
+      vitest-environment-nuxt: 2.0.0(@playwright/test@1.60.0)(@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2))(magicast@0.5.2)(playwright-core@1.60.0)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))
       vue: 3.5.34(typescript@5.9.3)
     optionalDependencies:
       '@playwright/test': 1.60.0
       playwright-core: 1.60.0
+      vitest: '@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2)'
     transitivePeerDependencies:
       - crossws
       - magicast
       - typescript
       - vite
 
-  '@nuxt/vite-builder@4.4.5(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.12.0)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.8.2)':
+  '@nuxt/vite-builder@4.4.5(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.12.0)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2))(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
       '@nuxt/kit': 4.4.5(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
@@ -7537,7 +7882,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)
+      nuxt: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -7553,8 +7898,8 @@ snapshots:
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
-      rolldown: 1.0.1
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.1)(rollup@4.60.4)
+      rolldown: 1.2.4
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.4)(rollup@4.60.4)
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@biomejs/biome'
@@ -7587,7 +7932,7 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.5(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@24.12.0)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.8.2)':
+  '@nuxt/vite-builder@4.4.5(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@24.12.0)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
       '@nuxt/kit': 4.4.5(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
@@ -7605,7 +7950,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)
+      nuxt: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -7621,8 +7966,76 @@ snapshots:
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
-      rolldown: 1.0.1
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.1)(rollup@4.60.4)
+      rolldown: 1.2.4
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.4)(rollup@4.60.4)
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@biomejs/biome'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - eslint
+      - less
+      - magicast
+      - meow
+      - optionator
+      - oxlint
+      - publint
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - unrun
+      - vls
+      - vti
+      - vue-tsc
+      - yaml
+
+  '@nuxt/vite-builder@4.4.5(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@24.12.0)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2))(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.8.2)':
+    dependencies:
+      '@nuxt/kit': 4.4.5(magicast@0.5.2)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
+      '@vitejs/plugin-vue': 6.0.7(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))
+      autoprefixer: 10.5.0(postcss@8.5.14)
+      consola: 3.4.2
+      cssnano: 7.1.9(postcss@8.5.14)
+      defu: 6.1.7
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      get-port-please: 3.2.0
+      jiti: 2.7.0
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      mocked-exports: 0.1.1
+      nuxt: 4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2)
+      nypm: 0.6.6
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      postcss: 8.5.14
+      seroval: 1.5.4
+      std-env: 4.1.0
+      ufo: 1.6.4
+      unenv: 2.0.0-rc.24
+      vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
+      vite-node: 5.3.0(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)
+      vite-plugin-checker: 0.13.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(eslint@9.39.2(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(typescript@5.9.3)
+      vue: 3.5.34(typescript@5.9.3)
+      vue-bundle-renderer: 2.2.0
+    optionalDependencies:
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
+      rolldown: 1.2.4
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.4)(rollup@4.60.4)
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@biomejs/biome'
@@ -7787,12 +8200,15 @@ snapshots:
 
   '@oxc-project/runtime@0.129.0': {}
 
+  '@oxc-project/runtime@0.133.0': {}
+
   '@oxc-project/types@0.128.0': {}
 
   '@oxc-project/types@0.129.0': {}
 
-  '@oxc-project/types@0.130.0':
-    optional: true
+  '@oxc-project/types@0.133.0': {}
+
+  '@oxc-project/types@0.144.0': {}
 
   '@oxc-transform/binding-android-arm-eabi@0.128.0':
     optional: true
@@ -8095,53 +8511,46 @@ snapshots:
 
   '@poppinss/exception@1.2.2': {}
 
-  '@rolldown/binding-android-arm64@1.0.1':
+  '@rolldown/binding-android-arm64@1.2.4':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.1':
+  '@rolldown/binding-darwin-arm64@1.2.4':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.1':
+  '@rolldown/binding-darwin-x64@1.2.4':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.1':
+  '@rolldown/binding-freebsd-x64@1.2.4':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.4':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+  '@rolldown/binding-linux-arm64-gnu@1.2.4':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.1':
+  '@rolldown/binding-linux-arm64-musl@1.2.4':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.4':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+  '@rolldown/binding-linux-s390x-gnu@1.2.4':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.1':
+  '@rolldown/binding-linux-x64-gnu@1.2.4':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.1':
+  '@rolldown/binding-linux-x64-musl@1.2.4':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.1':
+  '@rolldown/binding-openharmony-arm64@1.2.4':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.1':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+  '@rolldown/binding-win32-arm64-msvc@1.2.4':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.1':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.1':
+  '@rolldown/binding-win32-x64-msvc@1.2.4':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -8544,6 +8953,21 @@ snapshots:
       typescript: 5.9.3
       yaml: 2.8.2
 
+  '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)':
+    dependencies:
+      '@oxc-project/runtime': 0.133.0
+      '@oxc-project/types': 0.133.0
+      lightningcss: 1.32.0
+      postcss: 8.5.14
+    optionalDependencies:
+      '@types/node': 24.12.0
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.43.1
+      typescript: 5.9.3
+      yaml: 2.8.2
+
   '@voidzero-dev/vite-plus-darwin-arm64@0.1.22':
     optional: true
 
@@ -8577,6 +9001,46 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
+      ws: 8.19.0
+    optionalDependencies:
+      '@types/node': 24.12.0
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@vitejs/devtools'
+      - bufferutil
+      - esbuild
+      - jiti
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - unrun
+      - utf-8-validate
+      - yaml
+
+  '@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)
+      es-module-lexer: 1.7.0
+      obug: 2.1.1
+      pixelmatch: 7.1.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      vite: 8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)
       ws: 8.19.0
     optionalDependencies:
       '@types/node': 24.12.0
@@ -9752,6 +10216,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -10373,34 +10841,67 @@ snapshots:
   lightningcss-android-arm64@1.32.0:
     optional: true
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-x64@1.32.0:
     optional: true
 
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
   lightningcss@1.32.0:
@@ -10418,6 +10919,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   lilconfig@3.1.3: {}
 
@@ -11054,6 +11571,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.18: {}
+
   nanotar@0.3.0: {}
 
   napi-build-utils@2.0.0: {}
@@ -11072,7 +11591,7 @@ snapshots:
       qs: 6.14.0
     optional: true
 
-  nitropack@2.13.4(@netlify/blobs@9.1.2)(oxc-parser@0.128.0)(rolldown@1.0.1):
+  nitropack@2.13.4(@netlify/blobs@9.1.2)(oxc-parser@0.128.0)(rolldown@1.2.4):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.4)
@@ -11125,7 +11644,7 @@ snapshots:
       pretty-bytes: 7.1.0
       radix3: 1.1.2
       rollup: 4.60.4
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.1)(rollup@4.60.4)
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.4)(rollup@4.60.4)
       scule: 1.3.0
       semver: 7.8.0
       serve-placeholder: 2.0.2
@@ -11137,7 +11656,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.3.0(oxc-parser@0.128.0)(rolldown@1.0.1)
+      unimport: 6.3.0(oxc-parser@0.128.0)(rolldown@1.2.4)
       unplugin-utils: 0.3.1
       unstorage: 1.17.5(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.1)
       untyped: 2.0.0
@@ -11228,16 +11747,16 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2):
+  nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@5.9.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.5)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))
+      '@nuxt/devtools': 3.2.4(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))
       '@nuxt/kit': 4.4.5(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.5(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(oxc-parser@0.128.0)(rolldown@1.0.1)(typescript@5.9.3)
+      '@nuxt/nitro-server': 4.4.5(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2))(oxc-parser@0.128.0)(rolldown@1.2.4)(typescript@5.9.3)
       '@nuxt/schema': 4.4.5
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.5(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.5(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.12.0)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.8.2)
+      '@nuxt/vite-builder': 4.4.5(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@22.12.0)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2))(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.8.2)
       '@unhead/vue': 2.1.15(vue@3.5.34(typescript@5.9.3))
       '@vue/shared': 3.5.34
       chokidar: 5.0.0
@@ -11279,7 +11798,7 @@ snapshots:
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
-      unimport: 6.3.0(oxc-parser@0.128.0)(rolldown@1.0.1)
+      unimport: 6.3.0(oxc-parser@0.128.0)(rolldown@1.2.4)
       unplugin: 3.0.0
       unrouting: 0.1.7
       untyped: 2.0.0
@@ -11360,16 +11879,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2):
+  nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@5.9.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.5)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 3.2.4(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))
       '@nuxt/kit': 4.4.5(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.5(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(oxc-parser@0.128.0)(rolldown@1.0.1)(typescript@5.9.3)
+      '@nuxt/nitro-server': 4.4.5(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(oxc-parser@0.128.0)(rolldown@1.2.4)(typescript@5.9.3)
       '@nuxt/schema': 4.4.5
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.5(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.5(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@24.12.0)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.8.2)
+      '@nuxt/vite-builder': 4.4.5(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@24.12.0)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.8.2)
       '@unhead/vue': 2.1.15(vue@3.5.34(typescript@5.9.3))
       '@vue/shared': 3.5.34
       chokidar: 5.0.0
@@ -11411,7 +11930,139 @@ snapshots:
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
-      unimport: 6.3.0(oxc-parser@0.128.0)(rolldown@1.0.1)
+      unimport: 6.3.0(oxc-parser@0.128.0)(rolldown@1.2.4)
+      unplugin: 3.0.0
+      unrouting: 0.1.7
+      untyped: 2.0.0
+      vue: 3.5.34(typescript@5.9.3)
+      vue-router: 5.0.7(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3))
+    optionalDependencies:
+      '@parcel/watcher': 2.5.6
+      '@types/node': 24.12.0
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@babel/plugin-proposal-decorators'
+      - '@babel/plugin-syntax-jsx'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@rollup/plugin-babel'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - better-sqlite3
+      - bufferutil
+      - cac
+      - commander
+      - db0
+      - drizzle-orm
+      - encoding
+      - esbuild
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - oxlint
+      - pinia
+      - publint
+      - rolldown
+      - rollup
+      - rollup-plugin-visualizer
+      - sass
+      - sass-embedded
+      - sqlite3
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - unrun
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vls
+      - vti
+      - vue-tsc
+      - xml2js
+      - yaml
+
+  nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2):
+    dependencies:
+      '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@5.9.3)
+      '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.5)(cac@6.7.14)(magicast@0.5.2)
+      '@nuxt/devtools': 3.2.4(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3))
+      '@nuxt/kit': 4.4.5(magicast@0.5.2)
+      '@nuxt/nitro-server': 4.4.5(@babel/core@7.29.0)(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2))(oxc-parser@0.128.0)(rolldown@1.2.4)(typescript@5.9.3)
+      '@nuxt/schema': 4.4.5
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.5(magicast@0.5.2))
+      '@nuxt/vite-builder': 4.4.5(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@types/node@24.12.0)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(magicast@0.5.2)(nuxt@4.4.5(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2))(optionator@0.9.4)(oxlint@1.63.0(oxlint-tsgolint@0.22.1))(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4))(rollup@4.60.4)(terser@5.43.1)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.8.2)
+      '@unhead/vue': 2.1.15(vue@3.5.34(typescript@5.9.3))
+      '@vue/shared': 3.5.34
+      chokidar: 5.0.0
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 2.0.1
+      defu: 6.1.7
+      devalue: 5.8.1
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      hookable: 6.1.1
+      ignore: 7.0.5
+      impound: 1.1.5
+      jiti: 2.7.0
+      klona: 2.0.6
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      nanotar: 0.3.0
+      nypm: 0.6.6
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      on-change: 6.0.2
+      oxc-minify: 0.128.0
+      oxc-parser: 0.128.0
+      oxc-transform: 0.128.0
+      oxc-walker: 0.7.0(oxc-parser@0.128.0)
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      picomatch: 4.0.4
+      pkg-types: 2.3.1
+      rou3: 0.8.1
+      scule: 1.3.0
+      semver: 7.8.0
+      std-env: 4.1.0
+      tinyglobby: 0.2.16
+      ufo: 1.6.4
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unimport: 6.3.0(oxc-parser@0.128.0)(rolldown@1.2.4)
       unplugin: 3.0.0
       unrouting: 0.1.7
       untyped: 2.0.0
@@ -11832,6 +12483,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  picomatch@4.0.5: {}
+
   pify@4.0.1: {}
 
   pixelmatch@7.1.0:
@@ -12031,6 +12684,12 @@ snapshots:
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -12330,36 +12989,34 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown@1.0.1:
+  rolldown@1.2.4:
     dependencies:
-      '@oxc-project/types': 0.130.0
+      '@oxc-project/types': 0.144.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.1
-      '@rolldown/binding-darwin-arm64': 1.0.1
-      '@rolldown/binding-darwin-x64': 1.0.1
-      '@rolldown/binding-freebsd-x64': 1.0.1
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.1
-      '@rolldown/binding-linux-arm64-gnu': 1.0.1
-      '@rolldown/binding-linux-arm64-musl': 1.0.1
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.1
-      '@rolldown/binding-linux-s390x-gnu': 1.0.1
-      '@rolldown/binding-linux-x64-gnu': 1.0.1
-      '@rolldown/binding-linux-x64-musl': 1.0.1
-      '@rolldown/binding-openharmony-arm64': 1.0.1
-      '@rolldown/binding-wasm32-wasi': 1.0.1
-      '@rolldown/binding-win32-arm64-msvc': 1.0.1
-      '@rolldown/binding-win32-x64-msvc': 1.0.1
-    optional: true
+      '@rolldown/binding-android-arm64': 1.2.4
+      '@rolldown/binding-darwin-arm64': 1.2.4
+      '@rolldown/binding-darwin-x64': 1.2.4
+      '@rolldown/binding-freebsd-x64': 1.2.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.4
+      '@rolldown/binding-linux-arm64-gnu': 1.2.4
+      '@rolldown/binding-linux-arm64-musl': 1.2.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.4
+      '@rolldown/binding-linux-s390x-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-musl': 1.2.4
+      '@rolldown/binding-openharmony-arm64': 1.2.4
+      '@rolldown/binding-win32-arm64-msvc': 1.2.4
+      '@rolldown/binding-win32-x64-msvc': 1.2.4
 
-  rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4):
+  rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.60.4):
     dependencies:
       open: 11.0.0
       picomatch: 4.0.4
       source-map: 0.7.6
       yargs: 18.0.0
     optionalDependencies:
-      rolldown: 1.0.1
+      rolldown: 1.2.4
       rollup: 4.60.4
 
   rollup@4.60.4:
@@ -12806,6 +13463,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
   tinypool@2.1.0: {}
 
   to-regex-range@5.0.1:
@@ -12896,7 +13558,7 @@ snapshots:
       ofetch: 1.5.1
       ohash: 2.0.11
 
-  unimport@6.3.0(oxc-parser@0.128.0)(rolldown@1.0.1):
+  unimport@6.3.0(oxc-parser@0.128.0)(rolldown@1.2.4):
     dependencies:
       acorn: 8.16.0
       escape-string-regexp: 5.0.0
@@ -12914,7 +13576,7 @@ snapshots:
       unplugin-utils: 0.3.1
     optionalDependencies:
       oxc-parser: 0.128.0
-      rolldown: 1.0.1
+      rolldown: 1.2.4
 
   unist-util-find-after@5.0.0:
     dependencies:
@@ -13060,25 +13722,35 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-dev-rpc@1.1.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)):
-    dependencies:
-      birpc: 2.9.0
-      vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
-      vite-hot-client: 2.1.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))
-
   vite-dev-rpc@1.1.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)):
     dependencies:
       birpc: 2.9.0
       vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
       vite-hot-client: 2.1.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))
 
-  vite-hot-client@2.1.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)):
+  vite-dev-rpc@1.1.0(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)):
     dependencies:
-      vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
+      birpc: 2.9.0
+      vite: 8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)
+      vite-hot-client: 2.1.0(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))
+
+  vite-dev-rpc@1.1.0(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)):
+    dependencies:
+      birpc: 2.9.0
+      vite: 8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)
+      vite-hot-client: 2.1.0(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))
 
   vite-hot-client@2.1.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)):
     dependencies:
       vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
+
+  vite-hot-client@2.1.0(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)):
+    dependencies:
+      vite: 8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)
+
+  vite-hot-client@2.1.0(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)):
+    dependencies:
+      vite: 8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)
 
   vite-node@5.3.0(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
@@ -13172,23 +13844,6 @@ snapshots:
       oxlint: 1.63.0(oxlint-tsgolint@0.22.1)
       typescript: 5.9.3
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.5(magicast@0.5.2))(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)):
-    dependencies:
-      ansis: 4.2.0
-      debug: 4.4.3
-      error-stack-parser-es: 1.0.5
-      ohash: 2.0.11
-      open: 10.2.0
-      perfect-debounce: 2.1.0
-      sirv: 3.0.2
-      unplugin-utils: 0.3.1
-      vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
-      vite-dev-rpc: 1.1.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))
-    optionalDependencies:
-      '@nuxt/kit': 4.4.5(magicast@0.5.2)
-    transitivePeerDependencies:
-      - supports-color
-
   vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.5(magicast@0.5.2))(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)):
     dependencies:
       ansis: 4.2.0
@@ -13206,15 +13861,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.4.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.5(magicast@0.5.2))(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)):
     dependencies:
-      estree-walker: 3.0.3
-      exsolve: 1.0.8
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      source-map-js: 1.2.1
-      vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
-      vue: 3.5.34(typescript@5.9.3)
+      ansis: 4.2.0
+      debug: 4.4.3
+      error-stack-parser-es: 1.0.5
+      ohash: 2.0.11
+      open: 10.2.0
+      perfect-debounce: 2.1.0
+      sirv: 3.0.2
+      unplugin-utils: 0.3.1
+      vite: 8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)
+      vite-dev-rpc: 1.1.0(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))
+    optionalDependencies:
+      '@nuxt/kit': 4.4.5(magicast@0.5.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.5(magicast@0.5.2))(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)):
+    dependencies:
+      ansis: 4.2.0
+      debug: 4.4.3
+      error-stack-parser-es: 1.0.5
+      ohash: 2.0.11
+      open: 10.2.0
+      perfect-debounce: 2.1.0
+      sirv: 3.0.2
+      unplugin-utils: 0.3.1
+      vite: 8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)
+      vite-dev-rpc: 1.1.0(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))
+    optionalDependencies:
+      '@nuxt/kit': 4.4.5(magicast@0.5.2)
+    transitivePeerDependencies:
+      - supports-color
 
   vite-plugin-vue-tracer@1.4.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3)):
     dependencies:
@@ -13224,6 +13903,26 @@ snapshots:
       pathe: 2.0.3
       source-map-js: 1.2.1
       vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
+      vue: 3.5.34(typescript@5.9.3)
+
+  vite-plugin-vue-tracer@1.4.0(vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3)):
+    dependencies:
+      estree-walker: 3.0.3
+      exsolve: 1.0.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      source-map-js: 1.2.1
+      vite: 8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)
+      vue: 3.5.34(typescript@5.9.3)
+
+  vite-plugin-vue-tracer@1.4.0(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(vue@3.5.34(typescript@5.9.3)):
+    dependencies:
+      estree-walker: 3.0.3
+      exsolve: 1.0.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      source-map-js: 1.2.1
+      vite: 8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)
       vue: 3.5.34(typescript@5.9.3)
 
   vite-plus@0.1.22(@types/node@24.12.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2):
@@ -13275,13 +13974,43 @@ snapshots:
       - vite
       - yaml
 
+  vite@8.2.1(@types/node@22.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.12.0
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.43.1
+      yaml: 2.8.2
+
+  vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.12.0
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.43.1
+      yaml: 2.8.2
+
   vitefu@1.1.2(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)):
     optionalDependencies:
       vite: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2)'
 
-  vitest-environment-nuxt@2.0.0(@playwright/test@1.60.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(magicast@0.5.2)(playwright-core@1.60.0)(typescript@5.9.3):
+  vitest-environment-nuxt@2.0.0(@playwright/test@1.60.0)(@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2))(magicast@0.5.2)(playwright-core@1.60.0)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2)):
     dependencies:
-      '@nuxt/test-utils': 4.0.3(@playwright/test@1.60.0)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(yaml@2.8.2))(magicast@0.5.2)(playwright-core@1.60.0)(typescript@5.9.3)
+      '@nuxt/test-utils': 4.0.3(@playwright/test@1.60.0)(@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))(yaml@2.8.2))(magicast@0.5.2)(playwright-core@1.60.0)(typescript@5.9.3)(vite@8.2.1(@types/node@24.12.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.43.1)(yaml@2.8.2))
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'

--- a/src/client/create-trpc-nuxt-client.ts
+++ b/src/client/create-trpc-nuxt-client.ts
@@ -1,4 +1,3 @@
-import type { AsyncData, AsyncDataOptions } from 'nuxt/app';
 import type {
   CreateTRPCClientOptions,
   OperationContext,
@@ -24,6 +23,7 @@ import type {
   inferAsyncIterableYield,
   RouterRecord,
 } from '@trpc/server/unstable-core-do-not-import';
+import type { AsyncData, AsyncDataOptions } from 'nuxt/app';
 import type { MaybeRefOrGetter, Ref, ShallowRef, UnwrapRef } from 'vue';
 
 import { createNuxtProxyDecoration } from './decoration-proxy';

--- a/src/client/decoration-proxy.ts
+++ b/src/client/decoration-proxy.ts
@@ -1,9 +1,9 @@
 import { useAsyncData } from '#imports';
-import type { AsyncDataOptions } from 'nuxt/app';
 import type { TRPCClient, TRPCRequestOptions } from '@trpc/client';
 import type { TRPCConnectionState } from '@trpc/client/unstable-internals';
 import type { AnyTRPCRouter } from '@trpc/server';
 import { createTRPCRecursiveProxy } from '@trpc/server';
+import type { AsyncDataOptions } from 'nuxt/app';
 import { getCurrentInstance, isRef, onScopeDispose, shallowRef, toRaw, toValue, watch } from 'vue';
 
 import { getMutationKeyInternal, getQueryKeyInternal } from './get-query-key';

--- a/src/runtime/types/nuxt-imports.d.ts
+++ b/src/runtime/types/nuxt-imports.d.ts
@@ -1,6 +1,12 @@
+// Build-time only. This mirrors the *values* Nuxt auto-imports so the library
+// source can compile against `#imports` without bundling Nuxt or h3.
+//
+// Only declare things Nuxt's generated barrels actually export. `#imports` is
+// built from auto-import registrations, which are values, so it is not a source
+// of types. Import types from `nuxt/app` / `h3` directly instead, otherwise the
+// emitted `.d.mts` ships a specifier that resolves to nothing in a consumer's
+// project and silently degrades to `any`. See #255.
 declare module '#imports' {
-  export type H3Event = import('h3').H3Event;
-  export type { AsyncData, AsyncDataOptions } from 'nuxt/app';
   export const useAsyncData: typeof import('nuxt/app').useAsyncData;
   export const useRequestHeaders: typeof import('nuxt/app').useRequestHeaders;
   export const eventHandler: typeof import('h3').eventHandler;

--- a/src/runtime/types/nuxt-imports.d.ts
+++ b/src/runtime/types/nuxt-imports.d.ts
@@ -1,11 +1,6 @@
-// Build-time only. This mirrors the *values* Nuxt auto-imports so the library
-// source can compile against `#imports` without bundling Nuxt or h3.
-//
-// Only declare things Nuxt's generated barrels actually export. `#imports` is
-// built from auto-import registrations, which are values, so it is not a source
-// of types. Import types from `nuxt/app` / `h3` directly instead, otherwise the
-// emitted `.d.mts` ships a specifier that resolves to nothing in a consumer's
-// project and silently degrades to `any`. See #255.
+// Values only. Nuxt generates `#imports` from auto-import registrations, so a type
+// imported through it resolves to nothing in a consumer's project.
+// @see https://github.com/wobsoriano/trpc-nuxt/issues/255
 declare module '#imports' {
   export const useAsyncData: typeof import('nuxt/app').useAsyncData;
   export const useRequestHeaders: typeof import('nuxt/app').useRequestHeaders;

--- a/src/server/create-trpc-nuxt-handler.ts
+++ b/src/server/create-trpc-nuxt-handler.ts
@@ -1,5 +1,4 @@
 import { eventHandler } from '#imports';
-import type { H3Event } from '#imports';
 import type { AnyTRPCRouter, inferRouterContext } from '@trpc/server';
 import type {
   FetchCreateContextFn,
@@ -7,6 +6,7 @@ import type {
   FetchHandlerRequestOptions,
 } from '@trpc/server/adapters/fetch';
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+import type { H3Event } from 'h3';
 
 import { defaultEndpoint } from '../shared';
 import { toWebRequest } from './utils';

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -1,5 +1,5 @@
 import { getRequestURL, getRequestWebStream } from '#imports';
-import type { H3Event } from '#imports';
+import type { H3Event } from 'h3';
 
 export function toWebRequest(event: H3Event): Request {
   // TODO: Prepare for h3 v2 https://github.com/h3js/h3/blob/main/MIGRATION.md#web-standards

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,6 +63,16 @@ export default defineConfig({
           '!apps/test/playwright-report/**',
         ],
       },
+      // Typechecks a consumer against the built `dist`, not `src`. Guards
+      // against shipped declarations that resolve to `any` downstream (#255).
+      'test:types': {
+        command: 'vp test',
+        cwd: 'apps/test',
+        dependsOn: ['build:lib'],
+        // Vitest writes its run cache under `node_modules/.vite`, which would
+        // otherwise invalidate this task on every run.
+        input: [{ auto: true }, '!apps/test/.nuxt/**', '!apps/test/node_modules/**'],
+      },
       'build:playground': {
         command: 'vp exec nuxi build',
         cwd: 'apps/playground',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,14 +63,11 @@ export default defineConfig({
           '!apps/test/playwright-report/**',
         ],
       },
-      // Typechecks a consumer against the built `dist`, not `src`. Guards
-      // against shipped declarations that resolve to `any` downstream (#255).
       'test:types': {
         command: 'vp test',
         cwd: 'apps/test',
         dependsOn: ['build:lib'],
-        // Vitest writes its run cache under `node_modules/.vite`, which would
-        // otherwise invalidate this task on every run.
+        // vitest writes its run cache under node_modules/.vite
         input: [{ auto: true }, '!apps/test/.nuxt/**', '!apps/test/node_modules/**'],
       },
       'build:playground': {


### PR DESCRIPTION
`#imports` is generated from auto-import registrations, so it exports values only. Type imports routed through it resolve to nothing in a consumer's project and silently degrade to `any`, which is how #255 shipped.

- Import `H3Event` from `h3` in the server entry, so no published declaration depends on `#imports` anymore
- Reduce the build-time `#imports` shim to the values Nuxt's barrels actually export, so a type import through it now fails the build instead of the consumer's editor
- Add vitest type tests in apps/test that typecheck a consumer against the built `dist` rather than `src`, wired into `vp run test:types` and CI

Note for future assertions: `toEqualTypeOf` does not catch this failure mode, since an unresolvable module yields TS's error type. `not.toBeAny()` and `@ts-expect-error` both do.